### PR TITLE
feat(middleware): Bind multiple handlers to a message

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ This installs version `v0.32.1`, but any other should be the same.
 Let's say it is `v6.5.0`. Afterwards, run `nvm install v6.5.0`.
 * Install **yarn** dependency manager. `npm install -g yarn`.
 * Type `yarn install` to install all dependencies.
-* Type `npm run typings install` to install all the standalone typings.
 * Good to go!
 
 ### Link for development (optional)

--- a/src/lib/collection/abstract-message-handling.collection.ts
+++ b/src/lib/collection/abstract-message-handling.collection.ts
@@ -1,0 +1,80 @@
+
+import { JsBusError } from "../errors/js-bus.error";
+
+export interface MessageHandlerPair<T = any> { message: any, handler: T }
+
+export abstract class AbstractMessageHandlingCollection<T> {
+
+  /**
+   * The generic collection to connect a message with an handler.
+   */
+  protected _collection: MessageHandlerPair<T>[];
+
+  /**
+   * Checks the duplications in the collection.
+   */
+  private _checksDuplications() {
+    // Gets all messages.
+    const messages = this._collection
+      .map((pair: MessageHandlerPair) => pair.message);
+
+    // Calculates groups based on messages and count the entries for a given message.
+    const groups = {};
+    for (const message of messages) {
+      groups[message] = !groups[message] ? 1 : groups[message] + 1;
+    }
+
+    // Checks if there is at least a duplication.
+    const isDuplicated = !!Object.values(groups)
+      .find((value: number) => value > 1);
+
+    // If not, we are fine.
+    if (!isDuplicated) {
+      return;
+    }
+
+    // Otherwise, throws an error.
+    throw new JsBusError(`There are duplications in the messages-handlers collection.`);
+  }
+
+  constructor(collection: MessageHandlerPair<T>[] = []) {
+    this._collection = collection;
+    // TODO: This doesn't work with minification.
+    // this._checksDuplications();
+  }
+
+  /**
+   * Determines if the provided handler is bound to the given message-handler pair.
+   */
+  protected abstract _isHandlerBoundToPair(handler: any, pair: MessageHandlerPair<T>): boolean;
+
+  /**
+   * Sets a collection. It will override the old one.
+   */
+  setCollection(collection: MessageHandlerPair<T>[]) {
+    this._collection = collection;
+    // this._checksDuplications();
+  }
+
+  /**
+   * Gets a handler given a specific message.
+   */
+  getHandler(message: any): T {
+    const handlers = this._collection
+      .filter((pair: MessageHandlerPair<T>) => pair.message === message)
+      .map((pair: MessageHandlerPair<T>) => pair.handler);
+
+    return handlers.length > 0 ? handlers[0] : undefined;
+  }
+
+  /**
+   * Gets a message given a specific handler.
+   */
+  getMessage(handler: T): any {
+    const messages = this._collection
+      .filter((pair: MessageHandlerPair<T>) => this._isHandlerBoundToPair(handler, pair))
+      .map((pair: MessageHandlerPair<T>) => pair.message);
+
+    return messages.length > 0 ? messages[0] : undefined;
+  };
+}

--- a/src/lib/collection/abstract-message-handling.collection.ts
+++ b/src/lib/collection/abstract-message-handling.collection.ts
@@ -3,7 +3,7 @@ import { JsBusError } from "../errors/js-bus.error";
 
 export interface MessageHandlerPair<T = any> { message: any, handler: T }
 
-export abstract class AbstractMessageHandlingCollection<T> {
+export abstract class AbstractMessageHandlingCollection<T, U = T> {
 
   /**
    * The generic collection to connect a message with an handler.
@@ -46,7 +46,7 @@ export abstract class AbstractMessageHandlingCollection<T> {
   /**
    * Determines if the provided handler is bound to the given message-handler pair.
    */
-  protected abstract _isHandlerBoundToPair(handler: any, pair: MessageHandlerPair<T>): boolean;
+  protected abstract _isHandlerBoundToPair(handler: U, pair: MessageHandlerPair<T>): boolean;
 
   /**
    * Sets a collection. It will override the old one.
@@ -70,7 +70,7 @@ export abstract class AbstractMessageHandlingCollection<T> {
   /**
    * Gets a message given a specific handler.
    */
-  getMessage(handler: T): any {
+  getMessage(handler: U): any {
     const messages = this._collection
       .filter((pair: MessageHandlerPair<T>) => this._isHandlerBoundToPair(handler, pair))
       .map((pair: MessageHandlerPair<T>) => pair.message);

--- a/src/lib/collection/concurrent-message-handling.collection.ts
+++ b/src/lib/collection/concurrent-message-handling.collection.ts
@@ -1,0 +1,19 @@
+
+// Defines a convenience type to describe the message/handlers pair.
+import { AbstractMessageHandlingCollection, MessageHandlerPair } from "./abstract-message-handling.collection";
+
+/**
+ * Defines a collection of the message/handlers pairs.
+ * It just offers a convenience interface to store and retrieve
+ * collection objects.
+ */
+export class ConcurrentMessageHandlingCollection extends AbstractMessageHandlingCollection<Function[]> {
+
+  /**
+   * @inheritDoc
+   */
+  protected _isHandlerBoundToPair(handler: any, pair: MessageHandlerPair<Function[]>): boolean {
+    return pair.handler.some((value: Function) => value === handler);
+  }
+
+}

--- a/src/lib/collection/concurrent-message-handling.collection.ts
+++ b/src/lib/collection/concurrent-message-handling.collection.ts
@@ -7,12 +7,12 @@ import { AbstractMessageHandlingCollection, MessageHandlerPair } from "./abstrac
  * It just offers a convenience interface to store and retrieve
  * collection objects.
  */
-export class ConcurrentMessageHandlingCollection extends AbstractMessageHandlingCollection<Function[]> {
+export class ConcurrentMessageHandlingCollection extends AbstractMessageHandlingCollection<Function[], Function> {
 
   /**
    * @inheritDoc
    */
-  protected _isHandlerBoundToPair(handler: any, pair: MessageHandlerPair<Function[]>): boolean {
+  protected _isHandlerBoundToPair(handler: Function, pair: MessageHandlerPair<Function[]>): boolean {
     return pair.handler.some((value: Function) => value === handler);
   }
 

--- a/src/lib/collection/message-handling.collection.ts
+++ b/src/lib/collection/message-handling.collection.ts
@@ -2,7 +2,7 @@
 // Defines a convenience type to describe the message/handler pair.
 import { JsBusError } from '../errors/js-bus.error';
 
-export interface MessageHandlerPair { message: any; handler: any; };
+export interface MessageHandlerPair { message: any; handlers: any[]; };
 
 /**
  * Defines a collection of the message/handler pairs.
@@ -54,10 +54,10 @@ export class MessageHandlingCollection {
   /**
    * Gets a handler given a specific message.
    */
-  getHandler(message: any): any {
+  getHandlers(message: any): any[] {
     const handlers = this._collection
       .filter((pair: MessageHandlerPair) => pair.message === message)
-      .map((pair: MessageHandlerPair) => pair.handler);
+      .map((pair: MessageHandlerPair) => pair.handlers);
 
     return handlers.length > 0 ? handlers[0] : undefined;
   }
@@ -67,7 +67,9 @@ export class MessageHandlingCollection {
    */
   getMessage(handler: any): any {
     const messages = this._collection
-      .filter((pair: MessageHandlerPair) => pair.handler === handler)
+      .filter((pair: MessageHandlerPair) =>
+        pair.handlers.some((value: any) => value === handler)
+      )
       .map((pair: MessageHandlerPair) => pair.message);
 
     return messages.length > 0 ? messages[0] : undefined;

--- a/src/lib/collection/message-handling.collection.ts
+++ b/src/lib/collection/message-handling.collection.ts
@@ -1,78 +1,19 @@
 
 // Defines a convenience type to describe the message/handler pair.
-import { JsBusError } from '../errors/js-bus.error';
-
-export interface MessageHandlerPair { message: any; handlers: any[]; };
+import { AbstractMessageHandlingCollection, MessageHandlerPair } from "./abstract-message-handling.collection";
 
 /**
  * Defines a collection of the message/handler pairs.
  * It just offers a convenience interface to store and retrieve
  * collection objects.
  */
-export class MessageHandlingCollection {
+export class MessageHandlingCollection extends AbstractMessageHandlingCollection<any> {
 
   /**
-   * Checks the duplications in the collection.
+   * @inheritDoc
    */
-  private _checksDuplications() {
-    // Gets all messages.
-    const messages = this._collection
-      .map((pair: MessageHandlerPair) => pair.message);
-
-    // Calculates groups based on messages and count the entries for a given message.
-    const groups = {};
-    for (const message of messages) {
-      groups[message] = !groups[message] ? 1 : groups[message] + 1;
-    }
-
-    // Checks if there is at least a duplication.
-    const isDuplicated = !!Object.values(groups)
-      .find((value: number) => value > 1);
-
-    // If not, we are fine.
-    if (!isDuplicated) {
-      return;
-    }
-
-    // Otherwise, throws an error.
-    throw new JsBusError(`There are duplications in the messages-handlers collection.`);
-  }
-
-  constructor(private _collection: MessageHandlerPair[] = []) {
-    // TODO: This doesn't work with minification.
-    // this._checksDuplications();
-  }
-
-  /**
-   * Sets a collection. It will override the old one.
-   */
-  setCollection(collection: MessageHandlerPair[]) {
-    this._collection = collection;
-    // this._checksDuplications();
-  }
-
-  /**
-   * Gets a handler given a specific message.
-   */
-  getHandlers(message: any): any[] {
-    const handlers = this._collection
-      .filter((pair: MessageHandlerPair) => pair.message === message)
-      .map((pair: MessageHandlerPair) => pair.handlers);
-
-    return handlers.length > 0 ? handlers[0] : undefined;
-  }
-
-  /**
-   * Gets a message given a specific handler.
-   */
-  getMessage(handler: any): any {
-    const messages = this._collection
-      .filter((pair: MessageHandlerPair) =>
-        pair.handlers.some((value: any) => value === handler)
-      )
-      .map((pair: MessageHandlerPair) => pair.message);
-
-    return messages.length > 0 ? messages[0] : undefined;
+  protected _isHandlerBoundToPair(handler: any, pair: MessageHandlerPair<any>): boolean {
+    return pair.handler === handler;
   }
 
 }

--- a/src/lib/resolver/class-map.handler-resolver.ts
+++ b/src/lib/resolver/class-map.handler-resolver.ts
@@ -24,9 +24,9 @@ export class ClassMapHandlerResolver implements MessageHandlerResolverInterface 
     // Extracts the identifier.
     const identifier = this._extractor.extract(message);
     // Gets the handler based on the message identifier.
-    const handlers = this._messageHandlingCollection.getHandlers(identifier);
+    const handler = this._messageHandlingCollection.getHandler(identifier);
     // Resolves the handler function.
-    return handlers.map(handler => this._callableResolver.resolve(handler));
+    return [ this._callableResolver.resolve(handler) ];
   }
 
 }

--- a/src/lib/resolver/class-map.handler-resolver.ts
+++ b/src/lib/resolver/class-map.handler-resolver.ts
@@ -20,13 +20,13 @@ export class ClassMapHandlerResolver implements MessageHandlerResolverInterface 
   /**
    * @inheritDoc
    */
-  getHandler(message: any): Function {
+  getHandlers(message: any): Function[] {
     // Extracts the identifier.
     const identifier = this._extractor.extract(message);
     // Gets the handler based on the message identifier.
-    const handler = this._messageHandlingCollection.getHandler(identifier);
+    const handlers = this._messageHandlingCollection.getHandlers(identifier);
     // Resolves the handler function.
-    return this._callableResolver.resolve(handler);
+    return handlers.map(handler => this._callableResolver.resolve(handler));
   }
 
 }

--- a/src/lib/resolver/functions-map.handler-resolver.ts
+++ b/src/lib/resolver/functions-map.handler-resolver.ts
@@ -1,0 +1,25 @@
+
+import { MessageHandlingCollection } from "../collection/message-handling.collection";
+import { MessageTypeExtractorInterface } from "../extractor/message-type-extractor.interface";
+import { MessageHandlerResolverInterface } from "./message-handler-resolver.interface";
+
+/**
+ * Provides the ability to resolve a set of handlers bound to a given message.
+ */
+export class FunctionsMapHandlerResolver implements MessageHandlerResolverInterface {
+
+  constructor(
+      private _messageHandlingCollection: MessageHandlingCollection,
+      private _extractor: MessageTypeExtractorInterface
+  ) {}
+
+    /**
+     * @inheritDoc
+     */
+    getHandlers(message: any): Function[] {
+      // Extracts the identifier.
+      const identifier = this._extractor.extract(message);
+      // Gets the function handlers based on the message identifier.
+      return this._messageHandlingCollection.getHandlers(identifier);
+    }
+}

--- a/src/lib/resolver/functions-map.handler-resolver.ts
+++ b/src/lib/resolver/functions-map.handler-resolver.ts
@@ -1,5 +1,5 @@
 
-import { MessageHandlingCollection } from "../collection/message-handling.collection";
+import { ConcurrentMessageHandlingCollection } from "../collection/concurrent-message-handling.collection";
 import { MessageTypeExtractorInterface } from "../extractor/message-type-extractor.interface";
 import { MessageHandlerResolverInterface } from "./message-handler-resolver.interface";
 
@@ -9,7 +9,7 @@ import { MessageHandlerResolverInterface } from "./message-handler-resolver.inte
 export class FunctionsMapHandlerResolver implements MessageHandlerResolverInterface {
 
   constructor(
-      private _messageHandlingCollection: MessageHandlingCollection,
+      private _messageHandlingCollection: ConcurrentMessageHandlingCollection,
       private _extractor: MessageTypeExtractorInterface
   ) {}
 
@@ -20,6 +20,6 @@ export class FunctionsMapHandlerResolver implements MessageHandlerResolverInterf
       // Extracts the identifier.
       const identifier = this._extractor.extract(message);
       // Gets the function handlers based on the message identifier.
-      return this._messageHandlingCollection.getHandlers(identifier);
+      return this._messageHandlingCollection.getHandler(identifier);
     }
 }

--- a/src/lib/resolver/message-handler-resolver.interface.ts
+++ b/src/lib/resolver/message-handler-resolver.interface.ts
@@ -8,5 +8,5 @@ export interface MessageHandlerResolverInterface {
    * @param {any} message The message to use to resolve the handler.
    * @return {Function} The handler function to handle the message.
    */
-    getHandler(message: any): Function;
+    getHandlers(message: any): Function[];
 }

--- a/src/public_api.ts
+++ b/src/public_api.ts
@@ -16,6 +16,7 @@ export { FunctionConstructorMessageTypeExtractor } from './lib/extractor/functio
 // Resolver
 export { MessageHandlerResolverInterface } from './lib/resolver/message-handler-resolver.interface';
 export { ClassMapHandlerResolver } from './lib/resolver/class-map.handler-resolver';
+export { FunctionsMapHandlerResolver } from './lib/resolver/functions-map.handler-resolver';
 
 // Handler
 export { AbstractDelegatesMessageHandlerMiddleware } from './lib/handler/abstract-delegates-message-handler.middleware';

--- a/src/public_api.ts
+++ b/src/public_api.ts
@@ -6,8 +6,9 @@ export { MessageBusAllowMiddleware } from './lib/bus/message-bus-allow-middlewar
 export { CallableResolverInterface } from './lib/callable-resolver/callable-resolver.interface';
 export { ServiceLocatorAwareCallableResolver } from './lib/callable-resolver/service-locator-aware.callable-resolver';
 
-// Collection
+// Collections
 export { MessageHandlingCollection, MessageHandlerPair } from './lib/collection/message-handling.collection';
+export { ConcurrentMessageHandlingCollection, MessageHandlersPair } from './lib/collection/concurrent-message-handling.collection';
 
 // Extractor
 export { MessageTypeExtractorInterface } from './lib/extractor/message-type-extractor.interface';

--- a/src/public_api.ts
+++ b/src/public_api.ts
@@ -7,8 +7,9 @@ export { CallableResolverInterface } from './lib/callable-resolver/callable-reso
 export { ServiceLocatorAwareCallableResolver } from './lib/callable-resolver/service-locator-aware.callable-resolver';
 
 // Collections
-export { MessageHandlingCollection, MessageHandlerPair } from './lib/collection/message-handling.collection';
-export { ConcurrentMessageHandlingCollection, MessageHandlersPair } from './lib/collection/concurrent-message-handling.collection';
+export { MessageHandlingCollection } from './lib/collection/message-handling.collection';
+export { ConcurrentMessageHandlingCollection } from './lib/collection/concurrent-message-handling.collection';
+export { MessageHandlerPair } from './lib/collection/abstract-message-handling.collection';
 
 // Extractor
 export { MessageTypeExtractorInterface } from './lib/extractor/message-type-extractor.interface';

--- a/tests/integration/command-bus/command-bus.integration.tests.ts
+++ b/tests/integration/command-bus/command-bus.integration.tests.ts
@@ -23,8 +23,8 @@ import { GoodCommandHandlerForTest } from '../../fixtures/good-command-handler-f
     this.serviceLocatorMock = Mock.ofType<Function>();
 
     const messageHandlingCollection = new MessageHandlingCollection([
-      { message: GoodCommandForTest, handler: GoodCommandHandlerForTest },
-      { message: EviCommandForTest, handler: EvilCommandHandlerForTest }
+      { message: GoodCommandForTest, handlers: [ GoodCommandHandlerForTest ] },
+      { message: EviCommandForTest, handlers: [ EvilCommandHandlerForTest ] }
     ]);
 
     const functionExtractor = new FunctionConstructorMessageTypeExtractor();

--- a/tests/integration/command-bus/command-bus.integration.tests.ts
+++ b/tests/integration/command-bus/command-bus.integration.tests.ts
@@ -23,8 +23,8 @@ import { GoodCommandHandlerForTest } from '../../fixtures/good-command-handler-f
     this.serviceLocatorMock = Mock.ofType<Function>();
 
     const messageHandlingCollection = new MessageHandlingCollection([
-      { message: GoodCommandForTest, handlers: [ GoodCommandHandlerForTest ] },
-      { message: EviCommandForTest, handlers: [ EvilCommandHandlerForTest ] }
+      { message: GoodCommandForTest, handler: GoodCommandHandlerForTest },
+      { message: EviCommandForTest, handler: EvilCommandHandlerForTest }
     ]);
 
     const functionExtractor = new FunctionConstructorMessageTypeExtractor();

--- a/tests/integration/query-bus/query-bus.integration.tests.ts
+++ b/tests/integration/query-bus/query-bus.integration.tests.ts
@@ -22,8 +22,8 @@ import { GoodQueryHandlerForTest } from '../../fixtures/good-query-handler-for-t
     this.serviceLocatorMock = Mock.ofType<Function>();
 
     const messageHandlingCollection = new MessageHandlingCollection([
-      { message: GoodQueryForTest, handlers: [ GoodQueryHandlerForTest ] },
-      { message: EvilQueryForTest, handlers: [ EvilQueryHandlerForTest ] }
+      { message: GoodQueryForTest, handler: GoodQueryHandlerForTest },
+      { message: EvilQueryForTest, handler: EvilQueryHandlerForTest }
     ]);
 
     const functionExtractor = new FunctionConstructorMessageTypeExtractor();

--- a/tests/integration/query-bus/query-bus.integration.tests.ts
+++ b/tests/integration/query-bus/query-bus.integration.tests.ts
@@ -22,8 +22,8 @@ import { GoodQueryHandlerForTest } from '../../fixtures/good-query-handler-for-t
     this.serviceLocatorMock = Mock.ofType<Function>();
 
     const messageHandlingCollection = new MessageHandlingCollection([
-      { message: GoodQueryForTest, handler: GoodQueryHandlerForTest },
-      { message: EvilQueryForTest, handler: EvilQueryHandlerForTest }
+      { message: GoodQueryForTest, handlers: [ GoodQueryHandlerForTest ] },
+      { message: EvilQueryForTest, handlers: [ EvilQueryHandlerForTest ] }
     ]);
 
     const functionExtractor = new FunctionConstructorMessageTypeExtractor();
@@ -52,7 +52,7 @@ import { GoodQueryHandlerForTest } from '../../fixtures/good-query-handler-for-t
     return this.queryBus.handle(query)
       .subscribe(
         (result: string) => {
-          result.should.be.eql('result-value');
+          result.should.be.eql([ 'result-value' ]);
 
           this.serviceLocatorMock.verifyAll();
         },
@@ -82,7 +82,7 @@ import { GoodQueryHandlerForTest } from '../../fixtures/good-query-handler-for-t
 
     return execution$
       .subscribe((result: string) => {
-        result.should.be.eql('result-value');
+        result.should.be.eql([ 'result-value' ]);
 
         this.serviceLocatorMock.verifyAll();
         queryHandlerMock.verifyAll();

--- a/tests/unit/collection/concurrent-message-handling.collection.ts
+++ b/tests/unit/collection/concurrent-message-handling.collection.ts
@@ -1,0 +1,73 @@
+
+import { suite, test, should } from '@js-bus/test';
+import { ConcurrentMessageHandlingCollection } from "../../../src/lib/collection/concurrent-message-handling.collection";
+
+class MessageTest {}
+
+class MessageHandlerTest {
+  handler1() {}
+
+  handler2() {}
+
+  handler3() {}
+}
+
+@suite class MessageHandlingCollectionUnitTests {
+
+  private concurrentMessageHandlingCollection: ConcurrentMessageHandlingCollection;
+
+  before() {
+    this.concurrentMessageHandlingCollection = new ConcurrentMessageHandlingCollection();
+  }
+
+  @test 'should return undefined if no collection is provided'() {
+    should.equal(this.concurrentMessageHandlingCollection.getHandler('message'), undefined);
+    should.equal(this.concurrentMessageHandlingCollection.getHandler(MessageTest), undefined);
+    should.equal(this.concurrentMessageHandlingCollection.getMessage(() => {}), undefined);
+  }
+
+  @test 'should return the correct handlers given a message'() {
+
+    const messageHandlerTest = new MessageHandlerTest();
+
+    this.concurrentMessageHandlingCollection.setCollection([
+      {
+        message: 'message',
+        handler: [
+          messageHandlerTest.handler1,
+          messageHandlerTest.handler2
+        ]
+      },
+      {
+        message: MessageTest,
+        handler: [ messageHandlerTest.handler3 ]
+      }
+    ]);
+    this.concurrentMessageHandlingCollection.getHandler('message').should.be.eql([
+      messageHandlerTest.handler1,
+      messageHandlerTest.handler2
+    ]);
+    this.concurrentMessageHandlingCollection.getHandler(MessageTest).should.be.eql([
+      messageHandlerTest.handler3
+    ]);
+  }
+
+  @test 'should return the correct message given a handler'() {
+
+    const messageHandlerTest = new MessageHandlerTest();
+
+    this.concurrentMessageHandlingCollection.setCollection([
+      { message: 'message', handler: [ messageHandlerTest.handler2 ] },
+      {
+        message: MessageTest,
+        handler: [
+          messageHandlerTest.handler1,
+          messageHandlerTest.handler3
+        ]
+      }
+    ]);
+    this.concurrentMessageHandlingCollection.getMessage(messageHandlerTest.handler2).should.be.eql('message');
+    this.concurrentMessageHandlingCollection.getMessage(messageHandlerTest.handler1).should.be.eql(MessageTest);
+    this.concurrentMessageHandlingCollection.getMessage(messageHandlerTest.handler3).should.be.eql(MessageTest);
+  }
+}

--- a/tests/unit/collection/message-handling.collection.unit.tests.ts
+++ b/tests/unit/collection/message-handling.collection.unit.tests.ts
@@ -15,25 +15,25 @@ class MessageHandlerTest {}
   }
 
   @test 'should return undefined if no collection is provided'() {
-    should.equal(this.messageHandlingCollection.getHandlers('message'), undefined);
+    should.equal(this.messageHandlingCollection.getHandler('message'), undefined);
     should.equal(this.messageHandlingCollection.getMessage('handler'), undefined);
-    should.equal(this.messageHandlingCollection.getHandlers(MessageTest), undefined);
+    should.equal(this.messageHandlingCollection.getHandler(MessageTest), undefined);
     should.equal(this.messageHandlingCollection.getMessage(MessageHandlerTest), undefined);
   }
 
   @test 'should return the correct handlers given a message'() {
     this.messageHandlingCollection.setCollection([
-      { message: 'message', handlers: [ 'handler' ] },
-      { message: MessageTest, handlers: [ MessageHandlerTest ] }
+      { message: 'message', handler: 'handler' },
+      { message: MessageTest, handler: MessageHandlerTest }
     ]);
-    this.messageHandlingCollection.getHandlers('message').should.be.eql([ 'handler' ]);
-    this.messageHandlingCollection.getHandlers(MessageTest).should.be.eql([ MessageHandlerTest ]);
+    this.messageHandlingCollection.getHandler('message').should.be.eql('handler');
+    this.messageHandlingCollection.getHandler(MessageTest).should.be.eql(MessageHandlerTest);
   }
 
   @test 'should return the correct message given a handler'() {
     this.messageHandlingCollection.setCollection([
-      { message: 'message', handlers: [ 'handler' ] },
-      { message: MessageTest, handlers: [ MessageHandlerTest ] }
+      { message: 'message', handler: 'handler' },
+      { message: MessageTest, handler: MessageHandlerTest }
     ]);
     this.messageHandlingCollection.getMessage('handler').should.be.eql('message');
     this.messageHandlingCollection.getMessage(MessageHandlerTest).should.be.eql(MessageTest);
@@ -42,9 +42,9 @@ class MessageHandlerTest {}
   @test @skip 'should throw error if there are duplications in the collection using string'() {
     (() => {
       this.messageHandlingCollection.setCollection([
-        { message: 'message', handlers: [ 'handler' ] },
-        { message: 'message', handlers: [ 'another handler' ] },
-        { message: MessageTest, handlers: [ MessageHandlerTest ] }
+        { message: 'message', handler: 'handler' },
+        { message: 'message', handler: 'another handler' },
+        { message: MessageTest, handler: MessageHandlerTest }
       ]);
     }).should.throw(JsBusError);
   }
@@ -52,9 +52,9 @@ class MessageHandlerTest {}
   @test @skip 'should throw error if there are duplications in the collection using classes'() {
     (() => {
       this.messageHandlingCollection.setCollection([
-        { message: 'message', handlers: [ 'handler' ] },
-        { message: MessageTest, handlers: [ MessageHandlerTest ] },
-        { message: MessageTest, handlers: [ Function ] }
+        { message: 'message', handler: 'handler' },
+        { message: MessageTest, handler: MessageHandlerTest },
+        { message: MessageTest, handler: Function }
       ]);
     }).should.throw(JsBusError);
   }

--- a/tests/unit/collection/message-handling.collection.unit.tests.ts
+++ b/tests/unit/collection/message-handling.collection.unit.tests.ts
@@ -15,25 +15,25 @@ class MessageHandlerTest {}
   }
 
   @test 'should return undefined if no collection is provided'() {
-    should.equal(this.messageHandlingCollection.getHandler('message'), undefined);
+    should.equal(this.messageHandlingCollection.getHandlers('message'), undefined);
     should.equal(this.messageHandlingCollection.getMessage('handler'), undefined);
-    should.equal(this.messageHandlingCollection.getHandler(MessageTest), undefined);
+    should.equal(this.messageHandlingCollection.getHandlers(MessageTest), undefined);
     should.equal(this.messageHandlingCollection.getMessage(MessageHandlerTest), undefined);
   }
 
-  @test 'should return the correct handler given a message'() {
+  @test 'should return the correct handlers given a message'() {
     this.messageHandlingCollection.setCollection([
-      { message: 'message', handler: 'handler' },
-      { message: MessageTest, handler: MessageHandlerTest }
+      { message: 'message', handlers: [ 'handler' ] },
+      { message: MessageTest, handlers: [ MessageHandlerTest ] }
     ]);
-    this.messageHandlingCollection.getHandler('message').should.be.eql('handler');
-    this.messageHandlingCollection.getHandler(MessageTest).should.be.eql(MessageHandlerTest);
+    this.messageHandlingCollection.getHandlers('message').should.be.eql([ 'handler' ]);
+    this.messageHandlingCollection.getHandlers(MessageTest).should.be.eql([ MessageHandlerTest ]);
   }
 
   @test 'should return the correct message given a handler'() {
     this.messageHandlingCollection.setCollection([
-      { message: 'message', handler: 'handler' },
-      { message: MessageTest, handler: MessageHandlerTest }
+      { message: 'message', handlers: [ 'handler' ] },
+      { message: MessageTest, handlers: [ MessageHandlerTest ] }
     ]);
     this.messageHandlingCollection.getMessage('handler').should.be.eql('message');
     this.messageHandlingCollection.getMessage(MessageHandlerTest).should.be.eql(MessageTest);
@@ -42,9 +42,9 @@ class MessageHandlerTest {}
   @test @skip 'should throw error if there are duplications in the collection using string'() {
     (() => {
       this.messageHandlingCollection.setCollection([
-        { message: 'message', handler: 'handler' },
-        { message: 'message', handler: 'another handler' },
-        { message: MessageTest, handler: MessageHandlerTest }
+        { message: 'message', handlers: [ 'handler' ] },
+        { message: 'message', handlers: [ 'another handler' ] },
+        { message: MessageTest, handlers: [ MessageHandlerTest ] }
       ]);
     }).should.throw(JsBusError);
   }
@@ -52,9 +52,9 @@ class MessageHandlerTest {}
   @test @skip 'should throw error if there are duplications in the collection using classes'() {
     (() => {
       this.messageHandlingCollection.setCollection([
-        { message: 'message', handler: 'handler' },
-        { message: MessageTest, handler: MessageHandlerTest },
-        { message: MessageTest, handler: Function }
+        { message: 'message', handlers: [ 'handler' ] },
+        { message: MessageTest, handlers: [ MessageHandlerTest ] },
+        { message: MessageTest, handlers: [ Function ] }
       ]);
     }).should.throw(JsBusError);
   }

--- a/tests/unit/handler/observables-delegates-message-handler.middleware.unit.tests.ts
+++ b/tests/unit/handler/observables-delegates-message-handler.middleware.unit.tests.ts
@@ -18,7 +18,7 @@ import { MessageHandlerResolverInterface } from '../../../src/lib/resolver/messa
     );
   }
 
-  @test 'should resolve the handler if observables'() {
+  @test 'should resolve the handlers if observables'() {
 
     const message = 'message';
 
@@ -28,28 +28,35 @@ import { MessageHandlerResolverInterface } from '../../../src/lib/resolver/messa
       .returns(() => of('next-resolved'))
       .verifiable(Times.once());
 
-    const handlerMock = Mock.ofType(Function);
-    handlerMock
+    const handlerMock1 = Mock.ofType(Function);
+    handlerMock1
       .setup(x => x(message))
-      .returns(() => of('handler-resolved'))
+      .returns(() => of('handler1-resolved'))
+      .verifiable(Times.once());
+
+    const handlerMock2 = Mock.ofType(Function);
+    handlerMock2
+      .setup(x => x(message))
+      .returns(() => of('handler2-resolved'))
       .verifiable(Times.once());
 
     this.messageHandlerResolverMock
-      .setup(x => x.getHandler(message))
-      .returns(() => handlerMock.object)
+      .setup(x => x.getHandlers(message))
+      .returns(() => [ handlerMock1.object, handlerMock2.object ])
       .verifiable(Times.once());
 
     return this.delegatesToMessageHandlerMiddleware.handle(message, <any>nextMock.object)
       .subscribe((result: string) => {
 
-        result.should.be.eql('handler-resolved');
+        result.should.be.eql([ 'handler1-resolved', 'handler2-resolved' ]);
 
-        handlerMock.verifyAll();
+        handlerMock1.verifyAll();
+        handlerMock2.verifyAll();
         nextMock.verifyAll();
       });
   }
 
-  @test 'should resolve the handler if not observables'() {
+  @test 'should resolve the handlers if not observables'() {
 
     const message = 'message';
 
@@ -59,25 +66,32 @@ import { MessageHandlerResolverInterface } from '../../../src/lib/resolver/messa
       .returns(() => of('next-resolved'))
       .verifiable(Times.once());
 
-    const handlerMock = Mock.ofType(Function);
-    handlerMock
+    const handlerMock1 = Mock.ofType(Function);
+    handlerMock1
       .setup(x => x(message))
-      .returns(() => 'handler-resolved')
+      .returns(() => 'handler1-resolved')
+      .verifiable(Times.once());
+
+    const handlerMock2 = Mock.ofType(Function);
+    handlerMock2
+      .setup(x => x(message))
+      .returns(() => of('handler2-resolved'))
       .verifiable(Times.once());
 
     this.messageHandlerResolverMock
-      .setup(x => x.getHandler(message))
-      .returns(() => handlerMock.object)
+      .setup(x => x.getHandlers(message))
+      .returns(() => [ handlerMock1.object, handlerMock2.object ])
       .verifiable(Times.once());
 
     return this.delegatesToMessageHandlerMiddleware.handle(message, <any>nextMock.object)
       .subscribe(() => {
-        handlerMock.verifyAll();
+        handlerMock1.verifyAll();
+        handlerMock2.verifyAll();
         nextMock.verifyAll();
       });
   }
 
-  @test 'should resolve the handler if promise'() {
+  @test 'should resolve the handlers if promises'() {
 
     const message = 'message';
 
@@ -87,25 +101,32 @@ import { MessageHandlerResolverInterface } from '../../../src/lib/resolver/messa
       .returns(() => of('next-resolved'))
       .verifiable(Times.once());
 
-    const handlerMock = Mock.ofType(Function);
-    handlerMock
+    const handlerMock1 = Mock.ofType(Function);
+    handlerMock1
       .setup(x => x(message))
-      .returns(() => Promise.resolve('handler-resolved'))
+      .returns(() => Promise.resolve('handler1-resolved'))
+      .verifiable(Times.once());
+
+    const handlerMock2 = Mock.ofType(Function);
+    handlerMock2
+      .setup(x => x(message))
+      .returns(() => of('handler2-resolved'))
       .verifiable(Times.once());
 
     this.messageHandlerResolverMock
-      .setup(x => x.getHandler(message))
-      .returns(() => handlerMock.object)
+      .setup(x => x.getHandlers(message))
+      .returns(() => [ handlerMock1.object, handlerMock2.object, ])
       .verifiable(Times.once());
 
     return this.delegatesToMessageHandlerMiddleware.handle(message, <any>nextMock.object)
       .subscribe(() => {
-        handlerMock.verifyAll();
+        handlerMock1.verifyAll();
+        handlerMock2.verifyAll();
         nextMock.verifyAll();
       });
   }
 
-  @test 'should resolve the handler if not observable and return the handle value'() {
+  @test 'should resolve the handlers if not observables and return the handle value'() {
 
     const message = 'message';
 
@@ -115,28 +136,35 @@ import { MessageHandlerResolverInterface } from '../../../src/lib/resolver/messa
       .returns(() => of('next-resolved'))
       .verifiable(Times.once());
 
-    const handlerMock = Mock.ofType(Function);
-    handlerMock
+    const handlerMock1 = Mock.ofType(Function);
+    handlerMock1
       .setup(x => x(message))
-      .returns(() => 'handler-resolved')
+      .returns(() => 'handler1-resolved')
+      .verifiable(Times.once());
+
+    const handlerMock2 = Mock.ofType(Function);
+    handlerMock2
+      .setup(x => x(message))
+      .returns(() => of('handler2-resolved'))
       .verifiable(Times.once());
 
     this.messageHandlerResolverMock
-      .setup(x => x.getHandler(message))
-      .returns(() => handlerMock.object)
+      .setup(x => x.getHandlers(message))
+      .returns(() => [ handlerMock1.object, handlerMock2.object ])
       .verifiable(Times.once());
 
     return this.delegatesToMessageHandlerMiddleware.handle(message, <any>nextMock.object)
       .subscribe((result: any) => {
 
-        result.should.be.eql('handler-resolved');
+        result.should.be.eql([ 'handler1-resolved', 'handler2-resolved' ]);
 
-        handlerMock.verifyAll();
+        handlerMock1.verifyAll();
+        handlerMock2.verifyAll();
         nextMock.verifyAll();
       });
   }
 
-  @test 'should rejected and don\'t catch the error if handler fails'() {
+  @test 'should rejected and don\'t catch the error if an handler fails'() {
 
     const message = 'message';
 
@@ -146,28 +174,34 @@ import { MessageHandlerResolverInterface } from '../../../src/lib/resolver/messa
       .returns(() => of('next-resolved'))
       .verifiable(Times.never());
 
-    const handlerMock = Mock.ofType(Function);
-    handlerMock
+    const handlerMock1 = Mock.ofType(Function);
+    handlerMock1
       .setup(x => x(message))
-      .throws(new Error('handler-error'))
+      .throws(new Error('handler1-error'))
+      .verifiable(Times.once());
+
+    const handlerMock2 = Mock.ofType(Function);
+    handlerMock2
+      .setup(x => x(message))
+      .returns(() => of('handler2-resolved'))
       .verifiable(Times.once());
 
     this.messageHandlerResolverMock
-      .setup(x => x.getHandler(message))
-      .returns(() => handlerMock.object)
+      .setup(x => x.getHandlers(message))
+      .returns(() => [ handlerMock1.object, handlerMock2.object ])
       .verifiable(Times.once());
 
     return this.delegatesToMessageHandlerMiddleware.handle(message, <any>nextMock.object)
       .subscribe(
-          () => { throw new Error('it-should-be-never-called'); },
-          (error: Error) => {
+      () => { throw new Error('it-should-be-never-called'); },
+      (error: Error) => {
 
-            error.message.should.be.eql('handler-error');
+        error.message.should.be.eql('handler1-error');
 
-            handlerMock.verifyAll();
-            nextMock.verifyAll();
-          }
-        );
+        handlerMock1.verifyAll();
+        nextMock.verifyAll();
+      }
+    );
   }
 
 }

--- a/tests/unit/resolver/class-map-handler.resolver.unit.tests.ts
+++ b/tests/unit/resolver/class-map-handler.resolver.unit.tests.ts
@@ -25,12 +25,12 @@ import { ClassMapHandlerResolver } from '../../../src/lib/resolver/class-map.han
     );
   }
 
-  @test 'should return a callable function to handle message'() {
+  @test 'should return a set of callable functions to handle message'() {
 
-    class MessageClass {};
+    class MessageClass {}
     const message = new MessageClass();
 
-    class HandlerClass { handle() {} };
+    class HandlerClass { handle() {} }
     const handler = new HandlerClass();
 
     this.extractorMock
@@ -39,8 +39,8 @@ import { ClassMapHandlerResolver } from '../../../src/lib/resolver/class-map.han
       .verifiable(Times.once());
 
     this.messageHandlingCollectionMock
-      .setup(x => x.getHandler(MessageClass))
-      .returns(() => HandlerClass)
+      .setup(x => x.getHandlers(MessageClass))
+      .returns(() => [ HandlerClass ])
       .verifiable(Times.once());
 
     this.callableResolverMock
@@ -48,7 +48,7 @@ import { ClassMapHandlerResolver } from '../../../src/lib/resolver/class-map.han
       .returns(() => handler.handle)
       .verifiable(Times.once());
 
-    this.classMapHandlerResolver.getHandler(message).should.be.eql(handler.handle);
+    this.classMapHandlerResolver.getHandlers(message).should.be.eql([ handler.handle ]);
 
     this.extractorMock.verifyAll();
     this.messageHandlingCollectionMock.verifyAll();
@@ -57,7 +57,7 @@ import { ClassMapHandlerResolver } from '../../../src/lib/resolver/class-map.han
 
   @test 'should re-throw the error if the extractor throws an error'() {
 
-    class MessageClass {};
+    class MessageClass {}
     const message = new MessageClass();
 
     this.extractorMock
@@ -65,14 +65,14 @@ import { ClassMapHandlerResolver } from '../../../src/lib/resolver/class-map.han
       .throws(new Error('extractor-error'))
       .verifiable(Times.once());
 
-    (() => { this.classMapHandlerResolver.getHandler(message); }).should.throw('extractor-error');
+    (() => { this.classMapHandlerResolver.getHandlers(message); }).should.throw('extractor-error');
 
     this.extractorMock.verifyAll();
   }
 
   @test 'should re-throw the error if the collection throws an error'() {
 
-    class MessageClass {};
+    class MessageClass {}
     const message = new MessageClass();
 
     this.extractorMock
@@ -81,11 +81,11 @@ import { ClassMapHandlerResolver } from '../../../src/lib/resolver/class-map.han
       .verifiable(Times.once());
 
     this.messageHandlingCollectionMock
-      .setup(x => x.getHandler(MessageClass))
+      .setup(x => x.getHandlers(MessageClass))
       .throws(new Error('collection-error'))
       .verifiable(Times.once());
 
-    (() => { this.classMapHandlerResolver.getHandler(message); }).should.throw('collection-error');
+    (() => { this.classMapHandlerResolver.getHandlers(message); }).should.throw('collection-error');
 
     this.extractorMock.verifyAll();
     this.messageHandlingCollectionMock.verifyAll();
@@ -93,10 +93,10 @@ import { ClassMapHandlerResolver } from '../../../src/lib/resolver/class-map.han
 
   @test 'should re-throw the error if the resolver throws an error'() {
 
-    class MessageClass {};
+    class MessageClass {}
     const message = new MessageClass();
 
-    class HandlerClass {};
+    class HandlerClass {}
 
     this.extractorMock
       .setup(x => x.extract(message))
@@ -104,8 +104,8 @@ import { ClassMapHandlerResolver } from '../../../src/lib/resolver/class-map.han
       .verifiable(Times.once());
 
     this.messageHandlingCollectionMock
-      .setup(x => x.getHandler(MessageClass))
-      .returns(() => HandlerClass)
+      .setup(x => x.getHandlers(MessageClass))
+      .returns(() => [ HandlerClass ])
       .verifiable(Times.once());
 
     this.callableResolverMock
@@ -113,7 +113,7 @@ import { ClassMapHandlerResolver } from '../../../src/lib/resolver/class-map.han
       .throws(new Error('resolver-error'))
       .verifiable(Times.once());
 
-    (() => { this.classMapHandlerResolver.getHandler(message); }).should.throw('resolver-error');
+    (() => { this.classMapHandlerResolver.getHandlers(message); }).should.throw('resolver-error');
 
     this.extractorMock.verifyAll();
     this.messageHandlingCollectionMock.verifyAll();

--- a/tests/unit/resolver/class-map-handler.resolver.unit.tests.ts
+++ b/tests/unit/resolver/class-map-handler.resolver.unit.tests.ts
@@ -39,8 +39,8 @@ import { ClassMapHandlerResolver } from '../../../src/lib/resolver/class-map.han
       .verifiable(Times.once());
 
     this.messageHandlingCollectionMock
-      .setup(x => x.getHandlers(MessageClass))
-      .returns(() => [ HandlerClass ])
+      .setup(x => x.getHandler(MessageClass))
+      .returns(() => HandlerClass)
       .verifiable(Times.once());
 
     this.callableResolverMock
@@ -81,7 +81,7 @@ import { ClassMapHandlerResolver } from '../../../src/lib/resolver/class-map.han
       .verifiable(Times.once());
 
     this.messageHandlingCollectionMock
-      .setup(x => x.getHandlers(MessageClass))
+      .setup(x => x.getHandler(MessageClass))
       .throws(new Error('collection-error'))
       .verifiable(Times.once());
 
@@ -104,8 +104,8 @@ import { ClassMapHandlerResolver } from '../../../src/lib/resolver/class-map.han
       .verifiable(Times.once());
 
     this.messageHandlingCollectionMock
-      .setup(x => x.getHandlers(MessageClass))
-      .returns(() => [ HandlerClass ])
+      .setup(x => x.getHandler(MessageClass))
+      .returns(() => HandlerClass)
       .verifiable(Times.once());
 
     this.callableResolverMock

--- a/tests/unit/resolver/functions-map.handler-resolver.unit.tests.ts
+++ b/tests/unit/resolver/functions-map.handler-resolver.unit.tests.ts
@@ -1,17 +1,17 @@
 
 import { suite, test, IMock, Mock, Times } from '@js-bus/test';
 import { FunctionsMapHandlerResolver } from "../../../src/lib/resolver/functions-map.handler-resolver";
-import { MessageHandlingCollection } from "../../../src/lib/collection/message-handling.collection";
 import { MessageTypeExtractorInterface } from "../../../src/lib/extractor/message-type-extractor.interface";
+import { ConcurrentMessageHandlingCollection } from "../../../src/lib/collection/concurrent-message-handling.collection";
 
 @suite class FunctionsMapHandlerResolverUnitTests {
 
   private functionsMapHandlerResolverUnitTest: FunctionsMapHandlerResolver;
-  private messageHandlingCollectionMock: IMock<MessageHandlingCollection>;
+  private messageHandlingCollectionMock: IMock<ConcurrentMessageHandlingCollection>;
   private extractorMock: IMock<MessageTypeExtractorInterface>;
 
   before() {
-    this.messageHandlingCollectionMock = Mock.ofType(MessageHandlingCollection);
+    this.messageHandlingCollectionMock = Mock.ofType(ConcurrentMessageHandlingCollection);
     this.extractorMock = Mock.ofType<MessageTypeExtractorInterface>();
 
     this.functionsMapHandlerResolverUnitTest = new FunctionsMapHandlerResolver(
@@ -34,7 +34,7 @@ import { MessageTypeExtractorInterface } from "../../../src/lib/extractor/messag
       .verifiable(Times.once());
 
     this.messageHandlingCollectionMock
-      .setup(x => x.getHandlers(MessageClass))
+      .setup(x => x.getHandler(MessageClass))
       .returns(() => [ handler1, handler2 ])
       .verifiable(Times.once());
 
@@ -70,7 +70,7 @@ import { MessageTypeExtractorInterface } from "../../../src/lib/extractor/messag
       .verifiable(Times.once());
 
     this.messageHandlingCollectionMock
-      .setup(x => x.getHandlers(MessageClass))
+      .setup(x => x.getHandler(MessageClass))
       .throws(new Error('collection-error'))
       .verifiable(Times.once());
 

--- a/tests/unit/resolver/functions-map.handler-resolver.unit.tests.ts
+++ b/tests/unit/resolver/functions-map.handler-resolver.unit.tests.ts
@@ -1,0 +1,82 @@
+
+import { suite, test, IMock, Mock, Times } from '@js-bus/test';
+import { FunctionsMapHandlerResolver } from "../../../src/lib/resolver/functions-map.handler-resolver";
+import { MessageHandlingCollection } from "../../../src/lib/collection/message-handling.collection";
+import { MessageTypeExtractorInterface } from "../../../src/lib/extractor/message-type-extractor.interface";
+
+@suite class FunctionsMapHandlerResolverUnitTests {
+
+  private functionsMapHandlerResolverUnitTest: FunctionsMapHandlerResolver;
+  private messageHandlingCollectionMock: IMock<MessageHandlingCollection>;
+  private extractorMock: IMock<MessageTypeExtractorInterface>;
+
+  before() {
+    this.messageHandlingCollectionMock = Mock.ofType(MessageHandlingCollection);
+    this.extractorMock = Mock.ofType<MessageTypeExtractorInterface>();
+
+    this.functionsMapHandlerResolverUnitTest = new FunctionsMapHandlerResolver(
+      this.messageHandlingCollectionMock.object,
+      this.extractorMock.object
+    );
+  }
+
+  @test 'should return a set of callable functions to handle the message'() {
+
+    class MessageClass {}
+    const message = new MessageClass();
+
+    const handler1 = () => {};
+    const handler2 = () => {};
+
+    this.extractorMock
+      .setup(x => x.extract(message))
+      .returns(() => MessageClass)
+      .verifiable(Times.once());
+
+    this.messageHandlingCollectionMock
+      .setup(x => x.getHandlers(MessageClass))
+      .returns(() => [ handler1, handler2 ])
+      .verifiable(Times.once());
+
+    this.functionsMapHandlerResolverUnitTest.getHandlers(message).should.be.eql([ handler1, handler2 ]);
+
+    this.extractorMock.verifyAll();
+    this.messageHandlingCollectionMock.verifyAll();
+  }
+
+  @test 'should re-throw the error if the extractor throws an error'() {
+
+    class MessageClass {}
+    const message = new MessageClass();
+
+    this.extractorMock
+      .setup(x => x.extract(message))
+      .throws(new Error('extractor-error'))
+      .verifiable(Times.once());
+
+    (() => { this.functionsMapHandlerResolverUnitTest.getHandlers(message); }).should.throw('extractor-error');
+
+    this.extractorMock.verifyAll();
+  }
+
+  @test 'should re-throw the error if the collection throws an error'() {
+
+    class MessageClass {}
+    const message = new MessageClass();
+
+    this.extractorMock
+      .setup(x => x.extract(message))
+      .returns(() => MessageClass)
+      .verifiable(Times.once());
+
+    this.messageHandlingCollectionMock
+      .setup(x => x.getHandlers(MessageClass))
+      .throws(new Error('collection-error'))
+      .verifiable(Times.once());
+
+    (() => { this.functionsMapHandlerResolverUnitTest.getHandlers(message); }).should.throw('collection-error');
+
+    this.extractorMock.verifyAll();
+    this.messageHandlingCollectionMock.verifyAll();
+  }
+}


### PR DESCRIPTION
BREAKING CHANGE: Message-handler pairs mapping now expects a set of handlers in place of a single
handler.

fix #53